### PR TITLE
create ExecJS to nicely execute JS code without messing with DOM

### DIFF
--- a/app.go
+++ b/app.go
@@ -4,14 +4,16 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/net/html"
 	"io"
 	"os"
 	"reflect"
 	"sync"
+
+	"golang.org/x/net/html"
 )
 
 var renderMutex sync.Mutex
+var execJSBuffer []string
 
 func render(e *Element, w io.Writer) error {
 	renderMutex.Lock()
@@ -34,6 +36,9 @@ func render(e *Element, w io.Writer) error {
 		return err
 	}
 	_, err = fmt.Fprintln(w)
+	for _, value := range execJSBuffer {
+		fmt.Fprintf(os.Stdout, "$%s\n", value)
+	}
 	return err
 }
 
@@ -61,4 +66,14 @@ func Run(body *Element) error {
 		}
 	}
 	return nil
+}
+
+//ExecJS executes JS code after a DOM update from gowd
+func ExecJS(js string) {
+	execJSBuffer = append(execJSBuffer, js)
+}
+
+//ExecJSNow Executes JS code in NWJS without waiting for a DOM update to be finished.
+func ExecJSNow(js string) {
+	execJSBuffer = append(execJSBuffer, js)
 }

--- a/app.go
+++ b/app.go
@@ -75,5 +75,5 @@ func ExecJS(js string) {
 
 //ExecJSNow Executes JS code in NWJS without waiting for a DOM update to be finished.
 func ExecJSNow(js string) {
-	execJSBuffer = append(execJSBuffer, js)
+	fmt.Fprintf(os.Stdout, "$%s\n", js)
 }

--- a/cmd/template/main.js
+++ b/cmd/template/main.js
@@ -17,7 +17,7 @@ function body_message(msg){
 }
 
 function start_process() {
-     body_message("Loading...");
+    body_message("Loading...");
 
     const spawn = require('child_process').spawn;
     child = spawn(goBinary,{maxBuffer:1024*500});
@@ -27,9 +27,15 @@ function start_process() {
         input: child.stdout
     })
 
-    rl.on('line', (data) => {        
-        console.log(`Received: ${data}`);
-        setPage(data);        
+	rl.on('line', (data) => {        
+		console.log(`Received: ${data}`);
+		
+        if (data.charAt(0) == "$") {
+            data = data.substr(1);
+            eval(data)
+        } else {
+            setPage(data);
+        }
     });
 
     child.stderr.on('data', (data) => {

--- a/element.go
+++ b/element.go
@@ -2,11 +2,12 @@ package gowd
 
 import (
 	"fmt"
-	"golang.org/x/net/html"
-	"golang.org/x/net/html/atom"
 	"io"
 	"os"
 	"strings"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 var (


### PR DESCRIPTION
this allows for other plugins for other CSS libraries to nicely execute code whenever needed.
MDL for example, needs to execute JS code for certain components to work.

the snackbar needs to run JS code to open, but if it runs before the HTMLDOM is updated it will not run properly and not show the snackbar.